### PR TITLE
fixed annoying link issue

### DIFF
--- a/src/components/formatters/song-artists-label.tsx
+++ b/src/components/formatters/song-artists-label.tsx
@@ -48,7 +48,7 @@ export function SongArtistsLabel(
                     }}
                 >
                     <Link
-                        href={`artist/${artist.id}`}
+                        href={`../artist/${artist.id}`}
                         className="text-on-surface-variant transition-colors hover:text-inherit"
                     >
                         <EntityName


### PR DESCRIPTION
On the rankings page, artist links lead to [lang]/rankings/artist/[id]. This results in dead links.
<img width="486" height="267" alt="image" src="https://github.com/user-attachments/assets/b983f96c-e4a0-45c4-a266-e6d918df8778" />
Instead, I prepended the ../ to match the song links, and remove the issue
